### PR TITLE
Make heuristic port detection work properly for https

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -40,13 +40,16 @@ function postToServer(postContent, hookid, matterUrl) {
     }
     //If the port is not initialized yet (neither from env, nor from query param)
     // use the defaults ports
-    if(!matterServerPort && matterProto == 'https')
+    if(!matterServerPort)
     {
-        matterServerPort = '443';
-    }
-    else
-    {
-        matterServerPort = '80';
+        if (matterProto == 'https')
+        {
+            matterServerPort = '443';
+        }
+        else
+        {
+            matterServerPort = '80';
+        }
     }
 
     console.log(matterServer + "-" + matterServerPort  + "-" + matterProto);


### PR DESCRIPTION
When MATTERMOST_SERVER_PROTO=https and MATTERMOST_SERVER_PORT=443 are both set in the environment, the port is correctly picked up but the protocol gets set to https. I broke up the logic for setting the protocol based on port into nested simple ifs rather than a single fancy if. Reads clearer and works better now.