### PR TITLE
Dockerize app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM node:6-onbuild
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Set the following environment variables to provide the Mattermost server details
 * Configure JIRA Webhooks to forward the hook (for the required JQL) to `http://<jira-matter-bridge-server>:3000/hooks/<mattermost hook id>`
 * That's it.
 
+## Docker Version
+Pull the image from Docker Hub and run a container:
+```sh
+docker run --rm -p 3000:3000 vrenjith/jira-matter-bridge
+```
+See also the example docker-compose.yml.
+
 ## Hosted Version
 
 * The app is hosted on a free dyno at https://jira-matter-bridge.herokuapp.com/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+# Example docker-compose
+version: "2"
+
+services:
+  jira-matter-bridge:
+    image: vrenjith/jira-matter-bridge
+    environment:
+      MATTERMOST_SERVER: mattermost
+


### PR DESCRIPTION
This pull request adds `Dockerfile` and example `docker-compose.yml`. It allows users can quickly run jira-matter-bridge by Docker.

README assumes that the Docker image is available as `vrenjith/jira-matter-bridge` in Docker Hub. After merged, please login to [Docker Hub](https://hub.docker.com) and setup the automated build from your repository in order to publish the Docker image. Let me know if you have any issue on setting up.

Thank you for the great app.