### PR TITLE
Add possibility to overwrite default mattermost channel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Set the following environment variable to enable debug log output:
 * Configure JIRA Webhooks to forward the hook (for the required JQL) to the url `http://<jira-matter-bridge-server>:3000/hooks/<mattermost hook id>`
 * You can append `/<channel>` to that url to overwrite the default mattermost channel associated with the hook id. Messages will be posted to this channel.
 * This integration supports the jira events `issue_created`, `issue_updated` and `issue_deleted`.
-* `issue_updated` events are only forwarded to mattermost when the `Status` of the issue has changed. You can specify which items are being tracked by appending the query parameter
-`track` denoting a comma separated list of events. For example `?track=Status,Assignee,Epic+Link`.
+* `issue_updated` events are only forwarded to mattermost when the `status` of the issue has changed. You can specify which items are being tracked by appending the query parameter
+`track` denoting a comma separated list of events. For example `?track=status,assignee,epic+link`.
 
 ## Docker Version
 Pull the image from Docker Hub and run a container:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ Set the following environment variables to provide the Mattermost server details
 * Start the app by running `npm start`
 * Configure Mattermost server and create a new [incoming webhooks](https://github.com/mattermost/platform/blob/master/doc/integrations/webhooks/Incoming-Webhooks.md) and note the hook-id (the part that appears after `hooks` in the hook URL.
 * Configure JIRA Webhooks to forward the hook (for the required JQL) to the url `http://<jira-matter-bridge-server>:3000/hooks/<mattermost hook id>`
-* You can append `/<channel>` to that url to overwrite the default mattermost channel associated with the hook id. Messages will be posted tho this channel.
-* That's it.
+* You can append `/<channel>` to that url to overwrite the default mattermost channel associated with the hook id. Messages will be posted to this channel.
+* This integration supports the jira events `issue_created`, `issue_updated` and `issue_deleted`.
+* `issue_updated` events are only forwarded to mattermost when the `Status` of the issue has changed. You can specify which items are being tracked by appending the query parameter
+`track` denoting a comma separated list of events. For example `?track=Status,Assignee,Epic+Link`.
 
 ## Docker Version
 Pull the image from Docker Hub and run a container:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Set the following environment variables to provide the Mattermost server details
 * Install the required modules by running `npm install`
 * Start the app by running `npm start`
 * Configure Mattermost server and create a new [incoming webhooks](https://github.com/mattermost/platform/blob/master/doc/integrations/webhooks/Incoming-Webhooks.md) and note the hook-id (the part that appears after `hooks` in the hook URL.
-* Configure JIRA Webhooks to forward the hook (for the required JQL) to `http://<jira-matter-bridge-server>:3000/hooks/<mattermost hook id>`
+* Configure JIRA Webhooks to forward the hook (for the required JQL) to the url `http://<jira-matter-bridge-server>:3000/hooks/<mattermost hook id>`
+* You can append `/<channel>` to that url to overwrite the default mattermost channel associated with the hook id. Messages will be posted tho this channel.
 * That's it.
 
 ## Docker Version

--- a/README.md
+++ b/README.md
@@ -24,21 +24,6 @@ Set the following environment variable to enable debug log output:
 ## Docker Version
 Pull the image from Docker Hub and run a container:
 ```sh
-docker run --rm -p 3000:3000 vrenjith/jira-matter-bridge
+docker run --rm -p 3000:3000 iteratec/jira-matter-bridge
 ```
 See also the example docker-compose.yml.
-
-## Hosted Version
-
-* The app is hosted on a free dyno at https://jira-matter-bridge.herokuapp.com/
-* If the Mattermost server and JIRA server are on public domain, you can directly use this hosted version.
-* In the JIRA Server, configure the webhook URL as given in this example
- * `https://jira-matter-bridge.herokuapp.com/hooks/<hookid from your mattermost server>?matterurl=<your mattermost server base url>`
-* E.g.:
- * `https://jira-matter-bridge.herokuapp.com/hooks/ckshz5joqigkfmj6po7fm4r8wh?matterurl=https://someserver.com`
- * `https://jira-matter-bridge.herokuapp.com/hooks/ckshz5joqigkfmj6po7fm4r8wh?matterurl=http://someserver.com:3000`
- * `https://jira-matter-bridge.herokuapp.com/hooks/ckshz5joqigkfmj6po7fm4r8wh?matterurl=https://someserver.com:8443`
-
-:warning: Since this is hosted on a free dyno, there is no guarantee that the messages will be delivered and it is recommended that you use a paid dyno at [Heroku](https://dashboard.heroku.com/new) using this repository as source.
-
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/vrenjith/jira-matter-bridge)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Set the following environment variables to provide the Mattermost server details
 * MATTERMOST_SERVER_PROTO - Default: http
 * MATTERMOST_SERVER - Default: localhost
 
+Set the following environment variable to enable debug log output:
+ * JIRA_MATTER_BRIDGE_DEBUG - Default: false
+
 ## Integration
 * Install the required modules by running `npm install`
 * Start the app by running `npm start`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Set the following environment variable to enable debug log output:
 * This integration supports the jira events `issue_created`, `issue_updated` and `issue_deleted`.
 * `issue_updated` events are only forwarded to mattermost when the `status` of the issue has changed. You can specify which items are being tracked by appending the query parameter
 `track` denoting a comma separated list of events. For example `?track=status,assignee,epic+link`.
+* As an exception to the last bullet point, `issue_updated` events are always forwarded if a comment was added to an issue.
 
 ## Docker Version
 Pull the image from Docker Hub and run a container:

--- a/app.js
+++ b/app.js
@@ -16,12 +16,8 @@ app.set('view engine', 'jade');
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));
-app.use(bodyParser.json({
-  limit: '50mb'
-}));
-app.use(bodyParser.urlencoded({
-  extended: false
-}));
+app.use(bodyParser.json({limit: '50mb'}));
+app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 

--- a/app.js
+++ b/app.js
@@ -16,8 +16,12 @@ app.set('view engine', 'jade');
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));
-app.use(bodyParser.json({limit: '50mb'}));
-app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json({
+  limit: '50mb'
+}));
+app.use(bodyParser.urlencoded({
+  extended: false
+}));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -186,6 +186,9 @@ router.post('/hooks/:hookid/:channel?', function(req, res, next) {
     else
     {
         console.log("Ignoring events which we don't understand");
+        res.render('index', {
+            title: 'Ignoring events which we don\'t understand'
+        });
         return;
     }
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -9,222 +9,242 @@ var HttpProxyAgent = require('http-proxy-agent');
 var debug = process.env.JIRA_MATTER_BRIDGE_DEBUG;
 
 function toTitleCase(str) {
-  return str.replace(/\w\S*/g, function(txt) {
-    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-  });
+    return str.replace(/\w\S*/g, function(txt) {
+        return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+    });
 }
 
 function debugLog(str) {
-  if (debug) {
+  if(debug) {
     console.log(str);
   }
 }
 
 function postToServer(postContent, hookid, channel, matterUrl) {
-  if (channel) {
-    debugLog("Informing mattermost channel: " + channel +
-      " with hookid: " + hookid);
-  } else {
-    debugLog("Informing mattermost channel: " + hookid);
-  }
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-
-  var agent, httpsagent, httpagent = null;
-  var https_proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
-  var http_proxy = process.env.HTTP_PROXY || process.env.http_proxy;
-  if (https_proxy) {
-    httpsagent = new HttpsProxyAgent(https_proxy);
-    debugLog("Using HTTPS proxy - " + https_proxy);
-  }
-  if (http_proxy) {
-    httpagent = new HttpProxyAgent(http_proxy);
-    debugLog("Using HTTP proxy - " + http_proxy);
-  }
-
-  var matterServer = process.env.MATTERMOST_SERVER || 'localhost';
-  var matterServerPort = process.env.MATTERMOST_SERVER_PORT;
-  var matterProto = process.env.MATTERMOST_SERVER_PROTO || 'http';
-  var matterPath = (process.env.MATTERMOST_SERVER_PATH || '/hooks/') + hookid;
-  var matterUsername = process.env.MATTERMOST_USERNAME || 'JIRA';
-  var matterIconUrl = process.env.MATTERMOST_ICON_URL ||
-    'https://design.atlassian.com/images/logo/favicon.png';
-
-  if (matterUrl) {
-    try {
-      var murl = url.parse(matterUrl);
-      matterServer = murl.hostname || matterServer;
-      matterServerPort = murl.port || matterServerPort;
-      matterProto = murl.protocol.replace(":", "") || matterProto;
-      matterPath = murl.pathname || matterPath;
-    } catch (err) {
-      debugLog(err);
+    if(channel)
+    {
+        debugLog("Informing mattermost channel: " + channel +
+            " with hookid: " + hookid);
     }
-  }
-  //If the port is not initialized yet (neither from env, nor from query param)
-  // use the defaults ports
-  if (!matterServerPort) {
-    if (matterProto == 'https') {
-      matterServerPort = '443';
-    } else {
-      matterServerPort = '80';
+    else
+    {
+        debugLog("Informing mattermost channel: " + hookid);
     }
-  }
-  debugLog(matterServer + "-" + matterServerPort + "-" + matterProto);
-  var proto;
-  if (matterProto == 'https') {
-    debugLog("Using https protocol");
-    proto = https;
-    agent = httpsagent;
-  } else {
-    debugLog("Using http protocol");
-    proto = http;
-    agent = httpagent;
-  }
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
-  var postData = '{"text": ' + JSON.stringify(postContent) +
-    ', "username": "' + matterUsername +
-    '", "icon_url": "' + matterIconUrl;
-  if (channel) {
-    postData += '", "channel": "' + channel;
-  }
-  postData += '"}';
-  debugLog(postData);
-
-  var post_options = {
-    host: matterServer,
-    port: matterServerPort,
-    path: matterPath,
-    method: 'POST',
-    agent: agent,
-    headers: {
-      'Content-Type': 'application/json',
-      'Content-Length': Buffer.byteLength(postData)
+    var agent, httpsagent, httpagent = null;
+    var https_proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+    var http_proxy = process.env.HTTP_PROXY || process.env.http_proxy;
+    if(https_proxy)
+    {
+        httpsagent = new HttpsProxyAgent(https_proxy);
+        debugLog("Using HTTPS proxy - " + https_proxy);
     }
-  };
+    if(http_proxy)
+    {
+        httpagent = new HttpProxyAgent(http_proxy);
+        debugLog("Using HTTP proxy - " + http_proxy);
+    }
 
-  debugLog(post_options);
+    var matterServer = process.env.MATTERMOST_SERVER || 'localhost';
+    var matterServerPort = process.env.MATTERMOST_SERVER_PORT;
+    var matterProto = process.env.MATTERMOST_SERVER_PROTO || 'http';
+    var matterPath = (process.env.MATTERMOST_SERVER_PATH || '/hooks/') + hookid;
+    var matterUsername = process.env.MATTERMOST_USERNAME || 'JIRA';
+    var matterIconUrl = process.env.MATTERMOST_ICON_URL || 'https://design.atlassian.com/images/logo/favicon.png';
 
-  try {
-    // Set up the request
-    var post_req = proto.request(post_options, function(res) {
-      res.setEncoding('utf8');
-      res.on('data', function(chunk) {
-        debugLog('Response: ' + chunk);
-      });
-      res.on('error', function(err) {
-        debugLog('Error: ' + err);
-      });
-    });
+    if(matterUrl)
+    {
+        try
+        {
+            var murl = url.parse(matterUrl);
+            matterServer = murl.hostname || matterServer;
+            matterServerPort = murl.port || matterServerPort;
+            matterProto = murl.protocol.replace(":","") || matterProto;
+            matterPath = murl.pathname || matterPath;
+        }
+        catch(err){debugLog(err);}
+    }
+    //If the port is not initialized yet (neither from env, nor from query param)
+    // use the defaults ports
+    if(!matterServerPort)
+    {
+        if (matterProto == 'https')
+        {
+            matterServerPort = '443';
+        }
+        else
+        {
+            matterServerPort = '80';
+        }
+    }
+    debugLog(matterServer + "-" + matterServerPort  + "-" + matterProto);
+    var proto;
+    if(matterProto == 'https')
+    {
+        debugLog("Using https protocol");
+        proto = https;
+        agent = httpsagent;
+    }
+    else
+    {
+        debugLog("Using http protocol");
+        proto = http;
+        agent = httpagent;
+    }
 
-    // post the data
-    post_req.write(postData);
-    post_req.end();
-  } catch (err) {
-    debugLog("Unable to reach mattermost server: " + err);
-  }
+    var postData = '{"text": ' + JSON.stringify(postContent) +
+            ', "username": "' + matterUsername +
+            '", "icon_url": "' + matterIconUrl;
+    if(channel)
+    {
+        postData += '", "channel": "' + channel;
+    }
+    postData += '"}';
+    debugLog(postData);
+
+    var post_options = {
+        host: matterServer,
+        port: matterServerPort,
+        path: matterPath,
+        method: 'POST',
+        agent: agent,
+        headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(postData)
+        }
+    };
+
+    debugLog(post_options);
+
+    try
+    {
+        // Set up the request
+        var post_req = proto.request(post_options, function(res) {
+            res.setEncoding('utf8');
+            res.on('data', function(chunk) {
+                debugLog('Response: ' + chunk);
+            });
+            res.on('error', function(err) {
+                debugLog('Error: ' + err);
+            });
+        });
+
+        // post the data
+        post_req.write(postData);
+        post_req.end();
+    }
+    catch(err)
+    {
+        debugLog("Unable to reach mattermost server: " + err);
+    }
 }
 
 router.get('/', function(req, res, next) {
-  res.render('index', {
-    title: 'JIRA Mattermost Bridge'
-  });
+    res.render('index', {
+        title: 'JIRA Mattermost Bridge'
+    });
 });
 
 router.get('/hooks/:hookid', function(req, res, next) {
-  res.render('index', {
-    title: 'JIRA Mattermost Bridge - You got it right'
-  });
+    res.render('index', {
+        title: 'JIRA Mattermost Bridge - You got it right'
+    });
 });
 
 router.post('/hooks/:hookid/:channel?', function(req, res, next) {
-  debugLog("Received update from JIRA");
-  var hookId = req.params.hookid;
-  var channel = req.params.channel;
+    debugLog("Received update from JIRA");
+    var hookId = req.params.hookid;
+    var channel = req.params.channel;
 
-  var webevent = req.body.webhookEvent;
-  var issueID = req.body.issue.key;
-  var issueRestUrl = req.body.issue.self;
-  var regExp = /(.*?)\/rest\/api\/.*/g;
-  var matches = regExp.exec(issueRestUrl);
-  var issueUrl = matches[1] + "/browse/" + issueID;
-  var summary = req.body.issue.fields.summary;
+    var webevent = req.body.webhookEvent;
+    var issueID = req.body.issue.key;
+    var issueRestUrl = req.body.issue.self;
+    var regExp = /(.*?)\/rest\/api\/.*/g;
+    var matches = regExp.exec(issueRestUrl);
+    var issueUrl = matches[1] + "/browse/" + issueID;
+    var summary = req.body.issue.fields.summary;
 
-  var matterUrl = req.query.matterurl;
-  var track = req.query.track || "status";
-  var trackedItems = track.split(",").map(function(item) {
-    return item.toLowerCase();
-  });
-
-  var displayName = req.body.user.displayName;
-  var avatar = req.body.user.avatarUrls["16x16"];
-  var changeLog = req.body.changelog;
-  var comment = req.body.comment;
-
-  var postContent;
-
-  if (webevent == "jira:issue_updated") {
-    postContent = "##### " + displayName + " updated [" + issueID + "](" +
-      issueUrl + "): " + summary;
-  } else if (webevent == "jira:issue_created") {
-    postContent = "##### " + displayName + " created [" + issueID + "](" +
-      issueUrl + "): " + summary;
-  } else if (webevent == "jira:issue_deleted") {
-    postContent = "##### " + displayName + " deleted [" + issueID + "](" +
-      issueUrl + "): " + summary;
-  } else {
-    debugLog("Ignoring events which we don't understand");
-    res.render('index', {
-      title: 'Ignoring events which we don\'t understand'
+    var matterUrl = req.query.matterurl;
+    var track = req.query.track || "status";
+    var trackedItems = track.split(",").map(function(item) {
+      return item.toLowerCase();
     });
-    return;
-  }
 
-  /* Only issue_updated events have change logs. If a comment was added to an
-  issue, the resulting issue_updated event does not have a change log. */
-  if (changeLog) {
-    var changedItems = changeLog.items;
+    var displayName = req.body.user.displayName;
+    var avatar = req.body.user.avatarUrls["16x16"];
+    var changeLog = req.body.changelog;
+    var comment = req.body.comment;
 
-    for (i = 0; i < changedItems.length; i++) {
-      debugLog("Field of changeLog.items[" + i + "] == " +
-        changedItems[i].field);
-      if (trackedItems.indexOf(changedItems[i].field.toLowerCase()) != -1) {
-        break;
-      }
-      if (i + 1 == changedItems.length) {
-        debugLog("Ignoring events that are not being tracked. " +
-          "Tracked events: " + track);
-        res.render("index", {
-          title: "Ignoring events that are not being tracked. " +
-            "Tracked events: " + track
+    var postContent;
+
+    if (webevent == "jira:issue_updated")
+    {
+        postContent = "##### " + displayName + " updated [" + issueID + "](" + issueUrl + "): " + summary;
+    }
+    else if(webevent == "jira:issue_created")
+    {
+        postContent = "##### " + displayName + " created [" + issueID + "](" + issueUrl + "): " + summary;
+    }
+    else if(webevent == "jira:issue_deleted")
+    {
+        postContent = "##### " + displayName + " deleted [" + issueID + "](" + issueUrl + "): " + summary;
+    }
+    else
+    {
+        debugLog("Ignoring events which we don't understand");
+        res.render('index', {
+            title: 'Ignoring events which we don\'t understand'
         });
         return;
-      }
     }
 
-    postContent +=
-      "\r\n| Field | Updated Value |\r\n|:----- |:-------------|\r\n";
+    /* Only issue_updated events have change logs. If a comment was added to an
+    issue, the resulting issue_updated event does not have a change log. */
+    if(changeLog)
+    {
+        var changedItems = changeLog.items;
 
-    for (i = 0; i < changedItems.length; i++) {
-      var item = changedItems[i];
-      var fieldName = item.field;
-      var fieldValue = item.toString;
-      if (!fieldValue) {
-        fieldValue = "-Cleared-";
-      }
-      postContent += "| " + toTitleCase(toMarkdown(fieldName)) + " | " +
-        toMarkdown(fieldValue) + " |\r\n";
+        for (i = 0; i < changedItems.length; i++) {
+          debugLog("Field of changeLog.items[" + i + "] == " +
+                   changedItems[i].field);
+          if (trackedItems.indexOf(changedItems[i].field.toLowerCase()) != -1) {
+            break;
+          }
+          if (i+1 == changedItems.length) {
+            debugLog("Ignoring events that are not being tracked. " +
+                        "Tracked events: " + track);
+            res.render("index", {
+                title: "Ignoring events that are not being tracked. " +
+                            "Tracked events: " + track
+            });
+            return;
+          }
+        }
+
+        postContent += "\r\n| Field | Updated Value |\r\n|:----- |:-------------|\r\n";
+
+        for (i = 0; i < changedItems.length; i++) {
+            var item = changedItems[i];
+            var fieldName = item.field;
+            var fieldValue = item.toString;
+            if(!fieldValue){
+                fieldValue = "-Cleared-";
+            }
+            postContent += "| " + toTitleCase(toMarkdown(fieldName)) + " | " + toMarkdown(fieldValue) + " |\r\n";
+        }
     }
-  }
 
-  if (comment) {
-    postContent += "\r\n##### Comment:\r\n" + toMarkdown(comment.body);
-  }
+    if(comment)
+    {
+        postContent += "\r\n##### Comment:\r\n" + toMarkdown(comment.body);
+    }
 
-  postToServer(postContent, hookId, channel, matterUrl);
+    postToServer(postContent, hookId, channel, matterUrl);
 
-  res.render('index', {
-    title: 'JIRA Mattermost Bridge - beauty, posted to JIRA'
-  });
+    res.render('index', {
+        title: 'JIRA Mattermost Bridge - beauty, posted to JIRA'
+    });
 });
 
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -172,7 +172,7 @@ router.post('/hooks/:hookid/:channel?', function(req, res, next) {
     var summary = req.body.issue.fields.summary;
 
     var matterUrl = req.query.matterurl;
-    var track = req.query.track || "Status";
+    var track = req.query.track || "status";
     var trackedItems = track.split(",");
 
     var displayName = req.body.user.displayName;

--- a/routes/index.js
+++ b/routes/index.js
@@ -154,6 +154,7 @@ router.post('/hooks/:hookid/:channel?', function(req, res, next) {
     console.log("Received update from JIRA");
     var hookId = req.params.hookid;
     var channel = req.params.channel;
+
     var webevent = req.body.webhookEvent;
     var issueID = req.body.issue.key;
     var issueRestUrl = req.body.issue.self;
@@ -163,6 +164,8 @@ router.post('/hooks/:hookid/:channel?', function(req, res, next) {
     var summary = req.body.issue.fields.summary;
 
     var matterUrl = req.query.matterurl;
+    var track = req.query.track || "Status";
+    var trackedItems = track.split(",");
 
     var displayName = req.body.user.displayName;
     var avatar = req.body.user.avatarUrls["16x16"];
@@ -194,7 +197,22 @@ router.post('/hooks/:hookid/:channel?', function(req, res, next) {
 
     if(changeLog)
     {
-        var changedItems = req.body.changelog.items;
+        var changedItems = changeLog.items;
+
+        for (i = 0; i < changedItems.length; i++) {
+          if (trackedItems.indexOf(changedItems[i].field) != -1) {
+            break;
+          }
+          if (i+1 == changedItems.length) {
+            console.log("Ignoring events that are not being tracked. " +
+                        "Tracked events: " + track);
+            res.render("index", {
+                title: "Ignoring events that are not being tracked. " +
+                            "Tracked events: " + track
+            });
+            return;
+          }
+        }
 
         postContent += "\r\n| Field | Updated Value |\r\n|:----- |:-------------|\r\n";
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -9,240 +9,220 @@ var HttpProxyAgent = require('http-proxy-agent');
 var debug = process.env.JIRA_MATTER_BRIDGE_DEBUG;
 
 function toTitleCase(str) {
-    return str.replace(/\w\S*/g, function(txt) {
-        return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-    });
+  return str.replace(/\w\S*/g, function(txt) {
+    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+  });
 }
 
 function debugLog(str) {
-  if(debug) {
+  if (debug) {
     console.log(str);
   }
 }
 
 function postToServer(postContent, hookid, channel, matterUrl) {
-    if(channel)
-    {
-        debugLog("Informing mattermost channel: " + channel +
-            " with hookid: " + hookid);
-    }
-    else
-    {
-        debugLog("Informing mattermost channel: " + hookid);
-    }
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+  if (channel) {
+    debugLog("Informing mattermost channel: " + channel +
+      " with hookid: " + hookid);
+  } else {
+    debugLog("Informing mattermost channel: " + hookid);
+  }
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
-    var agent, httpsagent, httpagent = null;
-    var https_proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
-    var http_proxy = process.env.HTTP_PROXY || process.env.http_proxy;
-    if(https_proxy)
-    {
-        httpsagent = new HttpsProxyAgent(https_proxy);
-        debugLog("Using HTTPS proxy - " + https_proxy);
-    }
-    if(http_proxy)
-    {
-        httpagent = new HttpProxyAgent(http_proxy);
-        debugLog("Using HTTP proxy - " + http_proxy);
-    }
+  var agent, httpsagent, httpagent = null;
+  var https_proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+  var http_proxy = process.env.HTTP_PROXY || process.env.http_proxy;
+  if (https_proxy) {
+    httpsagent = new HttpsProxyAgent(https_proxy);
+    debugLog("Using HTTPS proxy - " + https_proxy);
+  }
+  if (http_proxy) {
+    httpagent = new HttpProxyAgent(http_proxy);
+    debugLog("Using HTTP proxy - " + http_proxy);
+  }
 
-    var matterServer = process.env.MATTERMOST_SERVER || 'localhost';
-    var matterServerPort = process.env.MATTERMOST_SERVER_PORT;
-    var matterProto = process.env.MATTERMOST_SERVER_PROTO || 'http';
-    var matterPath = (process.env.MATTERMOST_SERVER_PATH || '/hooks/') + hookid;
-    var matterUsername = process.env.MATTERMOST_USERNAME || 'JIRA';
-    var matterIconUrl = process.env.MATTERMOST_ICON_URL || 'https://design.atlassian.com/images/logo/favicon.png';
+  var matterServer = process.env.MATTERMOST_SERVER || 'localhost';
+  var matterServerPort = process.env.MATTERMOST_SERVER_PORT;
+  var matterProto = process.env.MATTERMOST_SERVER_PROTO || 'http';
+  var matterPath = (process.env.MATTERMOST_SERVER_PATH || '/hooks/') + hookid;
+  var matterUsername = process.env.MATTERMOST_USERNAME || 'JIRA';
+  var matterIconUrl = process.env.MATTERMOST_ICON_URL ||
+    'https://design.atlassian.com/images/logo/favicon.png';
 
-    if(matterUrl)
-    {
-        try
-        {
-            var murl = url.parse(matterUrl);
-            matterServer = murl.hostname || matterServer;
-            matterServerPort = murl.port || matterServerPort;
-            matterProto = murl.protocol.replace(":","") || matterProto;
-            matterPath = murl.pathname || matterPath;
-        }
-        catch(err){debugLog(err);}
+  if (matterUrl) {
+    try {
+      var murl = url.parse(matterUrl);
+      matterServer = murl.hostname || matterServer;
+      matterServerPort = murl.port || matterServerPort;
+      matterProto = murl.protocol.replace(":", "") || matterProto;
+      matterPath = murl.pathname || matterPath;
+    } catch (err) {
+      debugLog(err);
     }
-    //If the port is not initialized yet (neither from env, nor from query param)
-    // use the defaults ports
-    if(!matterServerPort)
-    {
-        if (matterProto == 'https')
-        {
-            matterServerPort = '443';
-        }
-        else
-        {
-            matterServerPort = '80';
-        }
+  }
+  //If the port is not initialized yet (neither from env, nor from query param)
+  // use the defaults ports
+  if (!matterServerPort) {
+    if (matterProto == 'https') {
+      matterServerPort = '443';
+    } else {
+      matterServerPort = '80';
     }
-    debugLog(matterServer + "-" + matterServerPort  + "-" + matterProto);
-    var proto;
-    if(matterProto == 'https')
-    {
-        debugLog("Using https protocol");
-        proto = https;
-        agent = httpsagent;
-    }
-    else
-    {
-        debugLog("Using http protocol");
-        proto = http;
-        agent = httpagent;
-    }
+  }
+  debugLog(matterServer + "-" + matterServerPort + "-" + matterProto);
+  var proto;
+  if (matterProto == 'https') {
+    debugLog("Using https protocol");
+    proto = https;
+    agent = httpsagent;
+  } else {
+    debugLog("Using http protocol");
+    proto = http;
+    agent = httpagent;
+  }
 
-    var postData = '{"text": ' + JSON.stringify(postContent) +
-            ', "username": "' + matterUsername +
-            '", "icon_url": "' + matterIconUrl;
-    if(channel)
-    {
-        postData += '", "channel": "' + channel;
+  var postData = '{"text": ' + JSON.stringify(postContent) +
+    ', "username": "' + matterUsername +
+    '", "icon_url": "' + matterIconUrl;
+  if (channel) {
+    postData += '", "channel": "' + channel;
+  }
+  postData += '"}';
+  debugLog(postData);
+
+  var post_options = {
+    host: matterServer,
+    port: matterServerPort,
+    path: matterPath,
+    method: 'POST',
+    agent: agent,
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(postData)
     }
-    postData += '"}';
-    debugLog(postData);
+  };
 
-    var post_options = {
-        host: matterServer,
-        port: matterServerPort,
-        path: matterPath,
-        method: 'POST',
-        agent: agent,
-        headers: {
-            'Content-Type': 'application/json',
-            'Content-Length': Buffer.byteLength(postData)
-        }
-    };
+  debugLog(post_options);
 
-    debugLog(post_options);
+  try {
+    // Set up the request
+    var post_req = proto.request(post_options, function(res) {
+      res.setEncoding('utf8');
+      res.on('data', function(chunk) {
+        debugLog('Response: ' + chunk);
+      });
+      res.on('error', function(err) {
+        debugLog('Error: ' + err);
+      });
+    });
 
-    try
-    {
-        // Set up the request
-        var post_req = proto.request(post_options, function(res) {
-            res.setEncoding('utf8');
-            res.on('data', function(chunk) {
-                debugLog('Response: ' + chunk);
-            });
-            res.on('error', function(err) {
-                debugLog('Error: ' + err);
-            });
-        });
-
-        // post the data
-        post_req.write(postData);
-        post_req.end();
-    }
-    catch(err)
-    {
-        debugLog("Unable to reach mattermost server: " + err);
-    }
+    // post the data
+    post_req.write(postData);
+    post_req.end();
+  } catch (err) {
+    debugLog("Unable to reach mattermost server: " + err);
+  }
 }
 
 router.get('/', function(req, res, next) {
-    res.render('index', {
-        title: 'JIRA Mattermost Bridge'
-    });
+  res.render('index', {
+    title: 'JIRA Mattermost Bridge'
+  });
 });
 
 router.get('/hooks/:hookid', function(req, res, next) {
-    res.render('index', {
-        title: 'JIRA Mattermost Bridge - You got it right'
-    });
+  res.render('index', {
+    title: 'JIRA Mattermost Bridge - You got it right'
+  });
 });
 
 router.post('/hooks/:hookid/:channel?', function(req, res, next) {
-    debugLog("Received update from JIRA");
-    var hookId = req.params.hookid;
-    var channel = req.params.channel;
+  debugLog("Received update from JIRA");
+  var hookId = req.params.hookid;
+  var channel = req.params.channel;
 
-    var webevent = req.body.webhookEvent;
-    var issueID = req.body.issue.key;
-    var issueRestUrl = req.body.issue.self;
-    var regExp = /(.*?)\/rest\/api\/.*/g;
-    var matches = regExp.exec(issueRestUrl);
-    var issueUrl = matches[1] + "/browse/" + issueID;
-    var summary = req.body.issue.fields.summary;
+  var webevent = req.body.webhookEvent;
+  var issueID = req.body.issue.key;
+  var issueRestUrl = req.body.issue.self;
+  var regExp = /(.*?)\/rest\/api\/.*/g;
+  var matches = regExp.exec(issueRestUrl);
+  var issueUrl = matches[1] + "/browse/" + issueID;
+  var summary = req.body.issue.fields.summary;
 
-    var matterUrl = req.query.matterurl;
-    var track = req.query.track || "status";
-    var trackedItems = track.split(",").map(function(item) {
-      return item.toLowerCase();
+  var matterUrl = req.query.matterurl;
+  var track = req.query.track || "status";
+  var trackedItems = track.split(",").map(function(item) {
+    return item.toLowerCase();
+  });
+
+  var displayName = req.body.user.displayName;
+  var avatar = req.body.user.avatarUrls["16x16"];
+  var changeLog = req.body.changelog;
+  var comment = req.body.comment;
+
+  var postContent;
+
+  if (webevent == "jira:issue_updated") {
+    postContent = "##### " + displayName + " updated [" + issueID + "](" +
+      issueUrl + "): " + summary;
+  } else if (webevent == "jira:issue_created") {
+    postContent = "##### " + displayName + " created [" + issueID + "](" +
+      issueUrl + "): " + summary;
+  } else if (webevent == "jira:issue_deleted") {
+    postContent = "##### " + displayName + " deleted [" + issueID + "](" +
+      issueUrl + "): " + summary;
+  } else {
+    debugLog("Ignoring events which we don't understand");
+    res.render('index', {
+      title: 'Ignoring events which we don\'t understand'
     });
+    return;
+  }
 
-    var displayName = req.body.user.displayName;
-    var avatar = req.body.user.avatarUrls["16x16"];
-    var changeLog = req.body.changelog;
-    var comment = req.body.comment;
+  if (changeLog) {
+    var changedItems = changeLog.items;
 
-    var postContent;
-
-    if (webevent == "jira:issue_updated")
-    {
-        postContent = "##### " + displayName + " updated [" + issueID + "](" + issueUrl + "): " + summary;
-    }
-    else if(webevent == "jira:issue_created")
-    {
-        postContent = "##### " + displayName + " created [" + issueID + "](" + issueUrl + "): " + summary;
-    }
-    else if(webevent == "jira:issue_deleted")
-    {
-        postContent = "##### " + displayName + " deleted [" + issueID + "](" + issueUrl + "): " + summary;
-    }
-    else
-    {
-        debugLog("Ignoring events which we don't understand");
-        res.render('index', {
-            title: 'Ignoring events which we don\'t understand'
+    for (i = 0; i < changedItems.length; i++) {
+      debugLog("Field of changeLog.items[" + i + "] == " +
+        changedItems[i].field);
+      if (trackedItems.indexOf(changedItems[i].field.toLowerCase()) != -1) {
+        break;
+      }
+      if (i + 1 == changedItems.length) {
+        debugLog("Ignoring events that are not being tracked. " +
+          "Tracked events: " + track);
+        res.render("index", {
+          title: "Ignoring events that are not being tracked. " +
+            "Tracked events: " + track
         });
         return;
+      }
     }
 
-    if(changeLog)
-    {
-        var changedItems = changeLog.items;
+    postContent +=
+      "\r\n| Field | Updated Value |\r\n|:----- |:-------------|\r\n";
 
-        for (i = 0; i < changedItems.length; i++) {
-          debugLog("Field of changeLog.items[" + i + "] == " +
-                   changedItems[i].field);
-          if (trackedItems.indexOf(changedItems[i].field.toLowerCase()) != -1) {
-            break;
-          }
-          if (i+1 == changedItems.length) {
-            debugLog("Ignoring events that are not being tracked. " +
-                        "Tracked events: " + track);
-            res.render("index", {
-                title: "Ignoring events that are not being tracked. " +
-                            "Tracked events: " + track
-            });
-            return;
-          }
-        }
-
-        postContent += "\r\n| Field | Updated Value |\r\n|:----- |:-------------|\r\n";
-
-        for (i = 0; i < changedItems.length; i++) {
-            var item = changedItems[i];
-            var fieldName = item.field;
-            var fieldValue = item.toString;
-            if(!fieldValue){
-                fieldValue = "-Cleared-";
-            }
-            postContent += "| " + toTitleCase(toMarkdown(fieldName)) + " | " + toMarkdown(fieldValue) + " |\r\n";
-        }
+    for (i = 0; i < changedItems.length; i++) {
+      var item = changedItems[i];
+      var fieldName = item.field;
+      var fieldValue = item.toString;
+      if (!fieldValue) {
+        fieldValue = "-Cleared-";
+      }
+      postContent += "| " + toTitleCase(toMarkdown(fieldName)) + " | " +
+        toMarkdown(fieldValue) + " |\r\n";
     }
+  }
 
-    if(comment)
-    {
-        postContent += "\r\n##### Comment:\r\n" + toMarkdown(comment.body);
-    }
+  if (comment) {
+    postContent += "\r\n##### Comment:\r\n" + toMarkdown(comment.body);
+  }
 
-    postToServer(postContent, hookId, channel, matterUrl);
+  postToServer(postContent, hookId, channel, matterUrl);
 
-    res.render('index', {
-        title: 'JIRA Mattermost Bridge - beauty, posted to JIRA'
-    });
+  res.render('index', {
+    title: 'JIRA Mattermost Bridge - beauty, posted to JIRA'
+  });
 });
 
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -173,7 +173,9 @@ router.post('/hooks/:hookid/:channel?', function(req, res, next) {
 
     var matterUrl = req.query.matterurl;
     var track = req.query.track || "status";
-    var trackedItems = track.split(",");
+    var trackedItems = track.split(",").map(function(item) {
+      return item.toLowerCase();
+    });
 
     var displayName = req.body.user.displayName;
     var avatar = req.body.user.avatarUrls["16x16"];
@@ -210,7 +212,7 @@ router.post('/hooks/:hookid/:channel?', function(req, res, next) {
         for (i = 0; i < changedItems.length; i++) {
           debugLog("Field of changeLog.items[" + i + "] == " +
                    changedItems[i].field);
-          if (trackedItems.indexOf(changedItems[i].field) != -1) {
+          if (trackedItems.indexOf(changedItems[i].field.toLowerCase()) != -1) {
             break;
           }
           if (i+1 == changedItems.length) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -208,6 +208,8 @@ router.post('/hooks/:hookid/:channel?', function(req, res, next) {
         var changedItems = changeLog.items;
 
         for (i = 0; i < changedItems.length; i++) {
+          debugLog("Field of changeLog.items[" + i + "] == " +
+                   changedItems[i].field);
           if (trackedItems.indexOf(changedItems[i].field) != -1) {
             break;
           }

--- a/routes/index.js
+++ b/routes/index.js
@@ -179,6 +179,8 @@ router.post('/hooks/:hookid/:channel?', function(req, res, next) {
     return;
   }
 
+  /* Only issue_updated events have change logs. If a comment was added to an
+  issue, the resulting issue_updated event does not have a change log. */
   if (changeLog) {
     var changedItems = changeLog.items;
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -14,12 +14,6 @@ function toTitleCase(str) {
     });
 }
 
-function doConversion(str)
-{
-    return toMarkdown(str);
-}
-
-
 function debugLog(str) {
   if(debug) {
     console.log(str);
@@ -235,13 +229,13 @@ router.post('/hooks/:hookid/:channel?', function(req, res, next) {
             if(!fieldValue){
                 fieldValue = "-Cleared-";
             }
-            postContent += "| " + toTitleCase(doConversion(fieldName)) + " | " + doConversion(fieldValue) + " |\r\n";
+            postContent += "| " + toTitleCase(toMarkdown(fieldName)) + " | " + toMarkdown(fieldValue) + " |\r\n";
         }
     }
 
     if(comment)
     {
-        postContent += "\r\n##### Comment:\r\n" + doConversion(comment.body);
+        postContent += "\r\n##### Comment:\r\n" + toMarkdown(comment.body);
     }
 
     postToServer(postContent, hookId, channel, matterUrl);

--- a/routes/index.js
+++ b/routes/index.js
@@ -61,7 +61,7 @@ function postToServer(postContent, hookid, channel, matterUrl) {
             matterProto = murl.protocol.replace(":","") || matterProto;
             matterPath = murl.pathname || matterPath;
         }
-        catch(err){console.log(err)}
+        catch(err){console.log(err);}
     }
     //If the port is not initialized yet (neither from env, nor from query param)
     // use the defaults ports
@@ -112,7 +112,7 @@ function postToServer(postContent, hookid, channel, matterUrl) {
             'Content-Length': Buffer.byteLength(postData)
         }
     };
-    
+
     console.log(post_options);
 
     try
@@ -171,15 +171,15 @@ router.post('/hooks/:hookid/:channel?', function(req, res, next) {
 
     var postContent;
 
-    if (webevent == "jira:issue_updated") 
+    if (webevent == "jira:issue_updated")
     {
         postContent = "##### " + displayName + " updated [" + issueID + "](" + issueUrl + "): " + summary;
     }
-    else if(webevent == "jira:issue_created") 
+    else if(webevent == "jira:issue_created")
     {
         postContent = "##### " + displayName + " created [" + issueID + "](" + issueUrl + "): " + summary;
     }
-    else if(webevent == "jira:issue_deleted") 
+    else if(webevent == "jira:issue_deleted")
     {
         postContent = "##### " + displayName + " deleted [" + issueID + "](" + issueUrl + "): " + summary;
     }


### PR DESCRIPTION
The user should now be able to specify the channel by
using the url path /hooks/hookid/channel. The previous
url /hooks/hookid is still valid and uses the default channel
associated with the hook id.